### PR TITLE
chore: add The Pragmatic Programmer

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -734,6 +734,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Software Engineering at Google](https://abseil.io/resources/swe-book) - Titus Winters, Tom Manshreck, Hyrum Wright
 * [Software Environment Concepts](https://softwareconcepts.vercel.app) - Amr Elmohamady (:construction: *in process*)
 * [What I've Learned From Failure](https://leanpub.com/shippingsoftware/read) - Reginald Braithwaite
+* [The Pragmatic Programmer](https://github.com/lighthousand/books/blob/master/the-pragmatic-programmer.pdf) - Andrew Hunt, David Thomas (PDF)
 
 
 ### Programming

--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -733,8 +733,8 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Professional Software Development For Students](https://mixmastamyk.bitbucket.io/pro_soft_dev/intro.html) - Mike G. Miller
 * [Software Engineering at Google](https://abseil.io/resources/swe-book) - Titus Winters, Tom Manshreck, Hyrum Wright
 * [Software Environment Concepts](https://softwareconcepts.vercel.app) - Amr Elmohamady (:construction: *in process*)
-* [What I've Learned From Failure](https://leanpub.com/shippingsoftware/read) - Reginald Braithwaite
 * [The Pragmatic Programmer](https://github.com/lighthousand/books/blob/master/the-pragmatic-programmer.pdf) - Andrew Hunt, David Thomas (PDF)
+* [What I've Learned From Failure](https://leanpub.com/shippingsoftware/read) - Reginald Braithwaite
 
 
 ### Programming


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
### Description
The Pragmatic Programmer: From Journeyman to Master is a book about computer programming and software engineering, written by Andrew Hunt and David Thomas and published in October 1999. It is used as a textbook in related university courses.

### Why is this valuable (or not)?
This book teaches most of the crucial aspects of a programmer's mindset.

### How do we know it's really free?\
It is an old yet still valuable version

### For book lists, is it a book? For course lists, is it a course? etc.
It is a book

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
